### PR TITLE
isodate 0.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,23 +1,26 @@
-{% set version = "0.6.0" %}
+{% set name = "isodate" %}
+{% set version = "0.6.1" %}
+
 
 package:
-  name: isodate
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/i/isodate/isodate-{{ version }}.tar.gz
-  sha256: 2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9
+
 
 build:
-  number: 1
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - python
     - pip
-    - six
+    - setuptools
+    - wheel
   run:
     - python
     - six
@@ -26,16 +29,24 @@ test:
   imports:
     - isodate
     - isodate.tests
+  requires: 
+    - pip
+  commands: 
+    - pip check
 
 about:
-  home: http://cheeseshop.python.org/pypi/isodate
-  license: BSD 3-Clause
-  summary: 'An ISO 8601 date/time/duration parser and formatter.'
+  home: https://github.com/gweis/isodate/
+  license: BSD-3-Clause
+  license_family: BSD
+  # The upstream source hasn't a license_file for v0.6.1, only the master branch has it
+  license_url: https://github.com/gweis/isodate/blob/master/LICENSE
+  summary: An ISO 8601 date/time/duration parser and formatter.
   description: |
     This module implements ISO 8601 date, time and duration parsing. The
     implementation follows ISO8601:2004 standard, and implements only date/time
     representations mentioned in the standard.
   dev_url: https://github.com/gweis/isodate
+  doc_url: https://github.com/gweis/isodate/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: https://github.com/gweis/isodate/blob/0.6.1/CHANGES.txt
License:  https://github.com/gweis/isodate/blob/master/LICENSE
Requirements: https://github.com/gweis/isodate/blob/0.6.1/setup.py

Actions:
1. Apply an initial **percy** [patch](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/test_patch.json) and run locally a [script](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/updater_standalone.py) to: 
  - Remove `noarch python`
  - Add flags `--no-deps --no-build-isolation` to `script`
  - Add missing `setuptools` and `wheel` to `host`
  - Fix `python` in `host` and `run`
2. Update `home` url
3. Fix `summary`
4. Add `doc_url`
5. Add `license_url`
6. Fix license name
7. Add `license_family`

Notes:
- `azure-keyvault-secrets 4.7.0` requires it https://github.com/AnacondaRecipes/azure-keyvault-secrets-feedstock/blob/e72d32d7f16520bf9af636634975b2281bc1b171/recipe/meta.yaml#L25
